### PR TITLE
fix(schedule): decouple B2B/outdoor event creation from studio hours

### DIFF
--- a/lib/actions/schedule/events.ts
+++ b/lib/actions/schedule/events.ts
@@ -28,22 +28,26 @@ export async function scheduleNewEventAction(data: ScheduleEventInput) {
 		return { error: "Not authenticated" };
 	}
 
-	// RULE 1: Shop Hours Verification
-	let workingHours = await getWorkingHours();
-	if (!workingHours) {
-		workingHours = DEFAULT_HOURS;
-	}
+	// RULE 1: Shop Hours Verification — only enforced for in-studio event types.
+	// B2B and outdoor sessions are held off-site and are not bound to studio hours.
+	const isStudioEvent = data.type === "group" || data.type === "private";
+	if (isStudioEvent) {
+		let workingHours = await getWorkingHours();
+		if (!workingHours) {
+			workingHours = DEFAULT_HOURS;
+		}
 
-	const dayConfig = workingHours[data.weekday.toString()];
-	if (!dayConfig || !dayConfig.isOpen) {
-		return { error: "Studio is closed on this day." };
-	}
+		const dayConfig = workingHours[data.weekday.toString()];
+		if (!dayConfig || !dayConfig.isOpen) {
+			return { error: "Studio is closed on this day." };
+		}
 
-	// Simple string comparison works for HH:mm formats (e.g. "08:00" >= "07:00")
-	if (data.startTimeStr < dayConfig.start || data.endTimeStr > dayConfig.end) {
-		return {
-			error: `Requested time is outside open hours. The studio is open from ${dayConfig.start} to ${dayConfig.end} on this day.`,
-		};
+		// Simple string comparison works for HH:mm formats (e.g. "08:00" >= "07:00")
+		if (data.startTimeStr < dayConfig.start || data.endTimeStr > dayConfig.end) {
+			return {
+				error: `Requested time is outside open hours. The studio is open from ${dayConfig.start} to ${dayConfig.end} on this day.`,
+			};
+		}
 	}
 
 	// Get Token

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"


### PR DESCRIPTION
## Summary
- Studio working-hours check in `scheduleNewEventAction` now only applies to `group` and `private` events
- `b2b` and `outdoor` sessions bypass the studio opening schedule since they are held off-site
- Google Calendar anti-conflict check and auth checks remain unchanged for all event types

Closes #8

## Test plan
- [ ] Typecheck passes (`pnpm tsc --noEmit`)
- [ ] Lint passes (`pnpm lint`)
- [ ] On a weekday marked **closed** in Settings → Schedule: creating a `group`/`private` event is rejected with "Studio is closed on this day."
- [ ] On a weekday marked **closed**: creating a `b2b` or `outdoor` event succeeds
- [ ] Outside open hours on an open day: `group`/`private` rejected with "outside open hours" message
- [ ] Outside open hours: `b2b`/`outdoor` succeeds
- [ ] Created events land in Google Calendar