### PR TITLE
feat(schedule): sessions & events overhaul — design, UX, and lifecycle

### DIFF
--- a/app/(dashboard)/check-in/[eventId]/page.tsx
+++ b/app/(dashboard)/check-in/[eventId]/page.tsx
@@ -39,16 +39,21 @@ export default async function CheckInPage({ params }: PageProps) {
         notFound();
     }
 
-    const details = eventDetails as { 
-        summary?: string; 
+    const details = eventDetails as {
+        summary?: string;
         start?: { dateTime?: string; date?: string };
+        end?: { dateTime?: string; date?: string };
         extendedProperties?: { private?: { jnaninEventType?: string } };
     };
 
     const title = details.summary || "Unnamed Event";
     const startTime = details.start?.dateTime || details.start?.date;
+    const endTime = details.end?.dateTime || details.end?.date;
     const type = (details.extendedProperties?.private?.jnaninEventType as JnaninEventType) || "group";
-    
+    // Past events go into read-only attendance-history mode so operators can't
+    // accidentally backfill attendees after the session has ended.
+    const isPast = endTime ? new Date(endTime) < new Date() : false;
+
     // Fetch currently checked-in clients
     const attendanceRecords = await getEventAttendanceAction(eventId);
 
@@ -63,7 +68,7 @@ export default async function CheckInPage({ params }: PageProps) {
                             <span>Back to Schedule</span>
                         </Link>
                         <span className="bg-secondary text-secondary-foreground rounded-full px-4 py-1.5 text-xs font-bold tracking-widest uppercase">
-                            {type} Session
+                            {isPast ? `${type} · History` : `${type} Session`}
                         </span>
                     </div>
                     
@@ -80,10 +85,11 @@ export default async function CheckInPage({ params }: PageProps) {
 
             {/* Main Content Area */}
             <main className="relative z-20 mx-auto flex w-full max-w-4xl flex-1 flex-col gap-6 px-5 py-6 md:px-6">
-                <CheckInManager 
-                    eventId={eventId} 
-                    eventType={type} 
-                    initialAttendance={attendanceRecords} 
+                <CheckInManager
+                    eventId={eventId}
+                    eventType={type}
+                    initialAttendance={attendanceRecords}
+                    isPast={isPast}
                 />
             </main>
         </div>

--- a/components/schedule/check-in.tsx
+++ b/components/schedule/check-in.tsx
@@ -21,15 +21,17 @@ interface CheckInManagerProps {
     eventId: string;
     eventType: JnaninEventType | string;
     initialAttendance: AttendanceRecord[];
+    isPast?: boolean;
 }
 
-export function CheckInManager({ eventId, eventType, initialAttendance }: CheckInManagerProps) {
+export function CheckInManager({ eventId, eventType, initialAttendance, isPast = false }: CheckInManagerProps) {
     const [attendance, setAttendance] = useState<AttendanceRecord[]>(initialAttendance);
     const [selectedClient, setSelectedClient] = useState<ClientWithLogs | null>(null);
     const [showGuardrail, setShowGuardrail] = useState(false);
     const [isCheckingIn, setIsCheckingIn] = useState(false);
 
     const onClientSelected = (client: ClientWithLogs) => {
+        if (isPast) return; // safety: past events are read-only
         const hasAlerts = client.healthLogs?.some((log) => log.isAlert);
         if (hasAlerts) {
             setSelectedClient(client);
@@ -76,16 +78,24 @@ export function CheckInManager({ eventId, eventType, initialAttendance }: CheckI
             <div className="animate-slide-up flex w-full flex-col gap-6">
                 {!checkedInClient ? (
                     <div className="bg-card zen-shadow-lg flex min-h-[50vh] flex-col items-center justify-center gap-8 rounded-3xl p-8 transition-all md:p-12">
-                        <div className="bg-primary/10 rounded-full p-6">
-                            <User className="text-primary h-16 w-16" variant="Outline" />
+                        <div className="bg-muted rounded-full p-6">
+                            <User className="text-muted-foreground h-16 w-16" variant="Outline" />
                         </div>
                         <div className="flex flex-col gap-2 text-center">
-                            <h2 className="font-heading text-foreground text-2xl font-bold">Private Session Ready</h2>
-                            <p className="text-muted-foreground">Scan or search for the single client attending.</p>
+                            <h2 className="font-heading text-foreground text-2xl font-bold">
+                                {isPast ? "No Attendance Recorded" : "Private Session Ready"}
+                            </h2>
+                            <p className="text-muted-foreground">
+                                {isPast
+                                    ? "This private session ended with no client checked in."
+                                    : "Scan or search for the single client attending."}
+                            </p>
                         </div>
-                        <div className="mt-4 w-full max-w-md">
-                            <ClientSearch onSelectClient={onClientSelected} />
-                        </div>
+                        {!isPast ? (
+                            <div className="mt-4 w-full max-w-md">
+                                <ClientSearch onSelectClient={onClientSelected} />
+                            </div>
+                        ) : null}
                     </div>
                 ) : (
                     <div className="bg-card zen-shadow-lg relative flex flex-col gap-8 overflow-hidden rounded-3xl p-6 transition-all md:p-10">
@@ -164,10 +174,12 @@ export function CheckInManager({ eventId, eventType, initialAttendance }: CheckI
     // Group / Outdoor View
     return (
         <div className="animate-slide-up flex w-full flex-col gap-6">
-            {/* Search Bar Block — Zen Glass Surface */}
-            <div className="zen-glass zen-shadow-glow sticky top-[72px] z-30 rounded-3xl p-5 transition-all md:p-6">
-                <ClientSearch onSelectClient={onClientSelected} />
-            </div>
+            {/* Search Bar — hidden in read-only history mode so operators can't backfill attendees */}
+            {!isPast ? (
+                <div className="zen-glass zen-shadow-glow sticky top-[72px] z-30 rounded-3xl p-5 transition-all md:p-6">
+                    <ClientSearch onSelectClient={onClientSelected} />
+                </div>
+            ) : null}
 
             {/* Manifest List */}
             <div className="bg-card zen-shadow-lg min-h-[50vh] flex-1 rounded-3xl p-6 md:p-8">
@@ -178,10 +190,12 @@ export function CheckInManager({ eventId, eventType, initialAttendance }: CheckI
                         ) : (
                             <div className="bg-primary/10 rounded-2xl p-2"><People className="text-primary h-5 w-5" variant="Outline" /></div>
                         )}
-                        Active Manifest
+                        {isPast ? "Attendance Record" : "Active Manifest"}
                     </h2>
                     <div className="flex items-center gap-2">
-                        <span className="text-muted-foreground hidden text-sm font-medium sm:block">Total Check-ins</span>
+                        <span className="text-muted-foreground hidden text-sm font-medium sm:block">
+                            {isPast ? "Total Present" : "Total Check-ins"}
+                        </span>
                         <span className="bg-secondary text-secondary-foreground rounded-full px-2 py-0.5 font-bold">
                             {attendance.length}
                         </span>
@@ -191,8 +205,14 @@ export function CheckInManager({ eventId, eventType, initialAttendance }: CheckI
                 {attendance.length === 0 ? (
                     <div className="text-muted-foreground flex flex-col items-center justify-center py-20">
                         <People className="mb-6 h-20 w-20 opacity-15" variant="Outline" />
-                        <h3 className="font-heading text-foreground/60 text-xl font-semibold">The studio is empty</h3>
-                        <p className="text-muted-foreground mt-2 max-w-sm text-center">Use the search bar above to begin checking clients into the session.</p>
+                        <h3 className="font-heading text-foreground/60 text-xl font-semibold">
+                            {isPast ? "No one was checked in" : "The studio is empty"}
+                        </h3>
+                        <p className="text-muted-foreground mt-2 max-w-sm text-center">
+                            {isPast
+                                ? "This session ended with no attendance recorded."
+                                : "Use the search bar above to begin checking clients into the session."}
+                        </p>
                     </div>
                 ) : (
                     <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">

--- a/components/schedule/client.tsx
+++ b/components/schedule/client.tsx
@@ -1,31 +1,53 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 
 import { EventCard } from "@/components/schedule/events/card";
 import { NewSessionDialog } from "@/components/schedule/sessions/new-dialog";
+import {
+    Accordion,
+    AccordionContent,
+    AccordionItem,
+    AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import { CalendarEvent, GroupedEvents } from "@/lib/types";
+import { cn } from "@/lib/utils/ui";
 
-import { format, parseISO } from "date-fns";
+import { format, isToday as isTodayDate, parseISO } from "date-fns";
 import { Add } from "iconsax-reactjs";
 
 export function ScheduleClient({ initialEvents }: { initialEvents: CalendarEvent[] }) {
     const [isDialogOpen, setIsDialogOpen] = useState(false);
 
-    // Group events by day
-    const groupedEvents = initialEvents.reduce((acc, event) => {
-        const startIso = event.start?.dateTime;
-        if (!startIso) return acc;
-        
-        const dateKey = format(parseISO(startIso), "yyyy-MM-dd");
-        if (!acc[dateKey]) acc[dateKey] = [];
-        acc[dateKey].push(event);
-        return acc;
-    }, {} as GroupedEvents);
+    const { groupedEvents, sortedDates, todayKey } = useMemo(() => {
+        const grouped = initialEvents.reduce((acc, event) => {
+            const startIso = event.start?.dateTime;
+            if (!startIso) return acc;
+            const dateKey = format(parseISO(startIso), "yyyy-MM-dd");
+            if (!acc[dateKey]) acc[dateKey] = [];
+            acc[dateKey].push(event);
+            return acc;
+        }, {} as GroupedEvents);
 
-    // Sort dates
-    const sortedDates = Object.keys(groupedEvents).sort();
+        return {
+            groupedEvents: grouped,
+            sortedDates: Object.keys(grouped).sort(),
+            todayKey: format(new Date(), "yyyy-MM-dd"),
+        };
+    }, [initialEvents]);
+
+    // Controlled so the accordion opens today by default AND re-opens it whenever
+    // today appears in the list after a navigation/refresh.
+    const defaultOpen = useMemo(() => {
+        if (sortedDates.includes(todayKey)) return todayKey;
+        // Fall back to the first upcoming day so the operator always lands on
+        // something expanded rather than a wall of collapsed rows.
+        const firstFuture = sortedDates.find((d) => d >= todayKey);
+        return firstFuture ?? sortedDates[0] ?? "";
+    }, [sortedDates, todayKey]);
+
+    const [openDate, setOpenDate] = useState<string>(defaultOpen);
 
     return (
         <div className="space-y-8">
@@ -41,18 +63,54 @@ export function ScheduleClient({ initialEvents }: { initialEvents: CalendarEvent
                     <p className="text-muted-foreground">No upcoming sessions scheduled for this week.</p>
                 </div>
             ) : (
-                sortedDates.map((dateKey) => (
-                    <div key={dateKey} className="space-y-4">
-                        <h3 className="border-b pb-2 text-lg font-semibold">
-                            {format(parseISO(dateKey), "EEEE, MMMM do")}
-                        </h3>
-                        <div className="flex flex-col gap-3">
-                            {groupedEvents[dateKey].map((event) => (
-                                <EventCard key={event.id} event={event} />
-                            ))}
-                        </div>
-                    </div>
-                ))
+                <Accordion
+                    type="single"
+                    collapsible
+                    value={openDate}
+                    onValueChange={setOpenDate}
+                    className="flex flex-col gap-3"
+                >
+                    {sortedDates.map((dateKey) => {
+                        const count = groupedEvents[dateKey].length;
+                        const parsed = parseISO(dateKey);
+                        const isToday = isTodayDate(parsed);
+                        return (
+                            <AccordionItem
+                                key={dateKey}
+                                value={dateKey}
+                                className="bg-card zen-shadow rounded-2xl px-5 py-1"
+                            >
+                                <AccordionTrigger className="py-4 no-underline hover:no-underline">
+                                    <div className="flex flex-1 items-center justify-between gap-4">
+                                        <div className="flex items-center gap-3">
+                                            <h3
+                                                className={cn(
+                                                    "text-foreground font-heading text-lg font-semibold md:text-xl",
+                                                    isToday && "text-primary",
+                                                )}
+                                            >
+                                                {format(parsed, "EEEE, MMMM do")}
+                                            </h3>
+                                            {isToday ? (
+                                                <span className="bg-primary/10 text-primary rounded-full px-2.5 py-0.5 text-[10px] font-bold tracking-wider uppercase">
+                                                    Today
+                                                </span>
+                                            ) : null}
+                                        </div>
+                                        <span className="text-muted-foreground bg-muted/60 rounded-full px-3 py-1 text-xs font-semibold tracking-wide tabular-nums">
+                                            {count} {count === 1 ? "session" : "sessions"}
+                                        </span>
+                                    </div>
+                                </AccordionTrigger>
+                                <AccordionContent className="flex flex-col gap-3 pt-2 pb-4">
+                                    {groupedEvents[dateKey].map((event) => (
+                                        <EventCard key={event.id} event={event} />
+                                    ))}
+                                </AccordionContent>
+                            </AccordionItem>
+                        );
+                    })}
+                </Accordion>
             )}
 
             <NewSessionDialog open={isDialogOpen} onOpenChange={setIsDialogOpen} />

--- a/components/schedule/events/cancel-button.tsx
+++ b/components/schedule/events/cancel-button.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+
+import {
+    AlertDialog,
+    AlertDialogAction,
+    AlertDialogCancel,
+    AlertDialogContent,
+    AlertDialogDescription,
+    AlertDialogFooter,
+    AlertDialogHeader,
+    AlertDialogTitle,
+    AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
+import { Button } from "@/components/ui/button";
+import { cancelEventAction } from "@/lib/actions/schedule/events";
+
+import { Refresh, Trash } from "iconsax-reactjs";
+import { toast } from "sonner";
+
+export function CancelEventButton({
+    eventId,
+    eventTitle,
+}: {
+    eventId: string;
+    eventTitle?: string | null;
+}) {
+    const router = useRouter();
+    const [open, setOpen] = useState(false);
+    const [isPending, startTransition] = useTransition();
+
+    const handleConfirm = () => {
+        startTransition(async () => {
+            const result = await cancelEventAction(eventId);
+            if (result.success) {
+                toast.success("Session cancelled.");
+                setOpen(false);
+                router.refresh();
+            } else {
+                toast.error(result.error ?? "Failed to cancel session.");
+            }
+        });
+    };
+
+    return (
+        <AlertDialog open={open} onOpenChange={setOpen}>
+            <AlertDialogTrigger asChild>
+                <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    aria-label="Cancel session"
+                    title="Cancel session"
+                    className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 h-10 w-10 rounded-full transition-colors"
+                >
+                    <Trash className="h-4 w-4" variant="Bulk" />
+                </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+                <AlertDialogHeader>
+                    <AlertDialogTitle>Cancel this session?</AlertDialogTitle>
+                    <AlertDialogDescription>
+                        {eventTitle ? (
+                            <>
+                                <span className="font-heading text-foreground text-lg">
+                                    {eventTitle}
+                                </span>
+                                <br />
+                            </>
+                        ) : null}
+                        This will delete the event from Google Calendar. Any attendance
+                        records already taken will be preserved. This cannot be undone.
+                    </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                    <AlertDialogCancel disabled={isPending}>Keep session</AlertDialogCancel>
+                    <AlertDialogAction
+                        onClick={(e) => {
+                            e.preventDefault();
+                            handleConfirm();
+                        }}
+                        disabled={isPending}
+                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                    >
+                        {isPending ? (
+                            <Refresh className="mr-2 h-4 w-4 animate-spin" />
+                        ) : null}
+                        Yes, cancel it
+                    </AlertDialogAction>
+                </AlertDialogFooter>
+            </AlertDialogContent>
+        </AlertDialog>
+    );
+}

--- a/components/schedule/events/cancel-button.tsx
+++ b/components/schedule/events/cancel-button.tsx
@@ -17,7 +17,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { cancelEventAction } from "@/lib/actions/schedule/events";
 
-import { Refresh, Trash } from "iconsax-reactjs";
+import { CloseCircle, Danger, Refresh } from "iconsax-reactjs";
 import { toast } from "sonner";
 
 export function CancelEventButton({
@@ -53,14 +53,23 @@ export function CancelEventButton({
                     size="icon"
                     aria-label="Cancel session"
                     title="Cancel session"
-                    className="text-muted-foreground hover:text-destructive hover:bg-destructive/10 h-10 w-10 rounded-full transition-colors"
+                    className="text-muted-foreground/70 hover:text-destructive hover:bg-destructive/10 h-8 w-8 rounded-full backdrop-blur-sm transition-colors"
                 >
-                    <Trash className="h-4 w-4" variant="Bulk" />
+                    <CloseCircle className="h-5 w-5" variant="Bulk" />
                 </Button>
             </AlertDialogTrigger>
-            <AlertDialogContent>
+            <AlertDialogContent className="border-destructive/20 ring-destructive/10 ring-1">
+                <div
+                    aria-hidden
+                    className="from-destructive/70 to-destructive absolute top-0 left-0 h-1 w-full rounded-t-[inherit] bg-gradient-to-r"
+                />
                 <AlertDialogHeader>
-                    <AlertDialogTitle>Cancel this session?</AlertDialogTitle>
+                    <AlertDialogTitle className="text-destructive flex items-center gap-2.5">
+                        <span className="bg-destructive/10 flex h-9 w-9 shrink-0 items-center justify-center rounded-full">
+                            <Danger className="text-destructive h-5 w-5" variant="Bulk" />
+                        </span>
+                        Cancel this session?
+                    </AlertDialogTitle>
                     <AlertDialogDescription>
                         {eventTitle ? (
                             <>
@@ -77,12 +86,12 @@ export function CancelEventButton({
                 <AlertDialogFooter>
                     <AlertDialogCancel disabled={isPending}>Keep session</AlertDialogCancel>
                     <AlertDialogAction
+                        variant="destructive"
                         onClick={(e) => {
                             e.preventDefault();
                             handleConfirm();
                         }}
                         disabled={isPending}
-                        className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                     >
                         {isPending ? (
                             <Refresh className="mr-2 h-4 w-4 animate-spin" />

--- a/components/schedule/events/card.tsx
+++ b/components/schedule/events/card.tsx
@@ -52,7 +52,7 @@ const TYPE_META: Record<EventTypeKey, TypeMeta> = {
         badge: "bg-secondary ring-1 ring-secondary-2/60",
         ribbon: "from-secondary-3/20",
         cta: cn(
-            "bg-secondary-3 text-white hover:bg-secondary-3/90",
+            "bg-secondary-3 hover:bg-secondary-3/90 text-white",
             CTA_ROSE,
         ),
         liveGlow: "shadow-[0_6px_24px_rgba(214,127,125,0.5)]",
@@ -113,7 +113,7 @@ export function EventCard({ event }: { event: CalendarEvent }) {
             className={cn(
                 "group relative flex flex-col justify-between overflow-hidden rounded-3xl border-0 transition-all duration-300 ease-out md:flex-row md:items-center",
                 isLive
-                    ? "bg-card zen-shadow-md ring-primary/20 hover:zen-shadow-lg ring-1 hover:-translate-y-0.5"
+                    ? "bg-card zen-shadow-md hover:zen-shadow-lg ring-1 ring-green-500/50 hover:-translate-y-0.5"
                     : "bg-card zen-shadow hover:zen-shadow-md hover:-translate-y-0.5",
             )}
         >
@@ -160,9 +160,12 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                         </span>
                     )}
                     {isLive ? (
-                        <span className="inline-flex items-center">
-                            <span className="bg-destructive mr-1.5 h-2 w-2 animate-pulse rounded-full shadow-[0_0_8px_rgba(239,68,68,0.6)]"></span>
-                            <span className="text-destructive text-[11px] font-bold tracking-widest uppercase">Active</span>
+                        <span className="inline-flex items-center gap-1.5 rounded-full border border-green-500/20 bg-green-500/10 px-2.5 py-1 text-green-600 shadow-sm backdrop-blur-sm">
+                            <span className="relative flex h-2 w-2">
+                                <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-green-400 opacity-75"></span>
+                                <span className="relative inline-flex h-2 w-2 rounded-full bg-green-500"></span>
+                            </span>
+                            <span className="text-[10px] font-bold tracking-wider uppercase">Live</span>
                         </span>
                     ) : null}
                 </div>

--- a/components/schedule/events/card.tsx
+++ b/components/schedule/events/card.tsx
@@ -115,7 +115,7 @@ export function EventCard({ event }: { event: CalendarEvent }) {
     return (
         <Card
             className={cn(
-                "group relative flex flex-col justify-between overflow-hidden rounded-3xl border-0 transition-all duration-300 ease-out md:flex-row md:items-center",
+                "group border-border/70 relative flex flex-col justify-between overflow-hidden rounded-3xl border transition-all duration-300 ease-out md:flex-row md:items-center",
                 isLive
                     ? "bg-card zen-shadow-md hover:zen-shadow-lg ring-1 ring-green-500/50 hover:-translate-y-0.5"
                     : isPast

--- a/components/schedule/events/card.tsx
+++ b/components/schedule/events/card.tsx
@@ -10,7 +10,7 @@ import { cn } from "@/lib/utils/ui";
 
 import { format, isWithinInterval, parseISO, subMinutes } from "date-fns";
 import type { Icon } from "iconsax-reactjs";
-import { Buildings, Calendar, Clock, LoginCurve, Profile2User, Sun1, Tag, User } from "iconsax-reactjs";
+import { Buildings, Calendar, ClipboardTick, Clock, LoginCurve, Profile2User, Sun1, Tag, User } from "iconsax-reactjs";
 
 import { CancelEventButton } from "./cancel-button";
 import { HexPattern, LotusPattern, MandalaPattern, SunPattern } from "./patterns";
@@ -97,6 +97,9 @@ export function EventCard({ event }: { event: CalendarEvent }) {
         end: endTime,
     });
 
+    // Past events are read-only: no cancel, no check-in — only attendance history.
+    const isPast = endTime < now;
+
     const eventType = event.extendedProperties?.private?.jnaninEventType as EventTypeKey | undefined;
     const outdoorPrice = event.extendedProperties?.private?.outdoorPrice as string | undefined;
     const b2bPrice = event.extendedProperties?.private?.jnaninEventPrice as string | undefined;
@@ -115,9 +118,18 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                 "group relative flex flex-col justify-between overflow-hidden rounded-3xl border-0 transition-all duration-300 ease-out md:flex-row md:items-center",
                 isLive
                     ? "bg-card zen-shadow-md hover:zen-shadow-lg ring-1 ring-green-500/50 hover:-translate-y-0.5"
-                    : "bg-card zen-shadow hover:zen-shadow-md hover:-translate-y-0.5",
+                    : isPast
+                      ? "bg-card zen-shadow opacity-70 grayscale-[40%] hover:opacity-95"
+                      : "bg-card zen-shadow hover:zen-shadow-md hover:-translate-y-0.5",
             )}
         >
+            {/* Cancel affordance — X in the top-right corner. Hidden for past events (read-only). */}
+            {!isPast && event.id ? (
+                <div className="absolute top-2 right-2 z-20">
+                    <CancelEventButton eventId={event.id} eventTitle={event.summary} />
+                </div>
+            ) : null}
+
             {/* Left edge accent — colored gradient bleed */}
             {meta ? (
                 <div
@@ -134,7 +146,10 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                 <div
                     aria-hidden
                     className={cn(
-                        "pointer-events-none absolute -top-10 -right-16 h-[280px] w-[280px] opacity-[0.2] transition-all duration-700 ease-out group-hover:rotate-6 group-hover:opacity-[0.32]",
+                        "pointer-events-none absolute -top-10 -right-16 h-[280px] w-[280px] transition-all duration-700 ease-out",
+                        isPast
+                            ? "opacity-[0.1]"
+                            : "opacity-[0.2] group-hover:rotate-6 group-hover:opacity-[0.32]",
                         meta.accent,
                     )}
                 >
@@ -207,16 +222,13 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                 </div>
             </div>
 
-            <div className="relative mt-auto flex items-center gap-2 p-5 md:mt-0 md:bg-transparent md:p-6 md:pl-0">
-                {event.id ? (
-                    <CancelEventButton eventId={event.id} eventTitle={event.summary} />
-                ) : null}
+            <div className="relative mt-auto p-5 md:mt-0 md:bg-transparent md:p-6 md:pl-0">
                 {isOffsite ? (
                     <Button
                         asChild
                         disabled={!calendarLink}
                         className={cn(
-                            "min-h-[48px] flex-1 rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:flex-none",
+                            "min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto",
                             meta?.cta,
                         )}
                     >
@@ -233,15 +245,22 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                 ) : (
                     <Button
                         asChild
+                        variant={isPast ? "outline" : "default"}
                         className={cn(
-                            "min-h-[48px] flex-1 rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:flex-none",
-                            meta?.cta,
+                            "min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto",
+                            !isPast && meta?.cta,
                             isLive && meta?.liveGlow,
+                            isPast &&
+                                "text-muted-foreground border-muted-foreground/30 hover:text-foreground hover:border-muted-foreground/60",
                         )}
                     >
                         <Link href={`/check-in/${event.id}`}>
-                            <LoginCurve className="mr-2 h-4 w-4" variant="Bulk" />
-                            Check In
+                            {isPast ? (
+                                <ClipboardTick className="mr-2 h-4 w-4" variant="Bulk" />
+                            ) : (
+                                <LoginCurve className="mr-2 h-4 w-4" variant="Bulk" />
+                            )}
+                            {isPast ? "Attendance" : "Check In"}
                         </Link>
                     </Button>
                 )}

--- a/components/schedule/events/card.tsx
+++ b/components/schedule/events/card.tsx
@@ -1,22 +1,89 @@
 "use client";
 
+import type { ComponentType } from "react";
 import Link from "next/link";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardTitle } from "@/components/ui/card";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { CalendarEvent } from "@/lib/types";
 import { cn } from "@/lib/utils/ui";
 
-import { format, isWithinInterval, parseISO,subMinutes } from "date-fns";
-import { Clock, LinkCircle } from "iconsax-reactjs";
+import { format, isWithinInterval, parseISO, subMinutes } from "date-fns";
+import type { Icon } from "iconsax-reactjs";
+import { Buildings, Calendar, Clock, LoginCurve, Profile2User, Sun1, Tag, User } from "iconsax-reactjs";
+
+import { HexPattern, LotusPattern, MandalaPattern, SunPattern } from "./patterns";
+
+type EventTypeKey = "group" | "private" | "b2b" | "outdoor";
+
+type TypeMeta = {
+    label: string;
+    Icon: Icon;
+    Pattern: ComponentType<{ className?: string }>;
+    accent: string; // text + border color for badge/pattern
+    badge: string; // badge background
+    ribbon: string; // left edge gradient tint
+    cta: string; // CTA button bg + hover colored glow (establishes per-card harmony)
+    liveGlow: string; // always-on glow when the event is currently live
+};
+
+// Tailwind arbitrary-value shadows — these must be full static strings so the JIT picks them up.
+const CTA_TEAL = "hover:shadow-[0_6px_24px_rgba(29,126,142,0.45)] hover:-translate-y-0.5";
+const CTA_ROSE = "hover:shadow-[0_6px_24px_rgba(214,127,125,0.5)] hover:-translate-y-0.5";
+const CTA_VIOLET = "hover:shadow-[0_6px_24px_rgba(139,92,246,0.45)] hover:-translate-y-0.5";
+const CTA_AMBER = "hover:shadow-[0_6px_24px_rgba(245,158,11,0.45)] hover:-translate-y-0.5";
+
+const TYPE_META: Record<EventTypeKey, TypeMeta> = {
+    group: {
+        label: "Group Class",
+        Icon: Profile2User,
+        Pattern: MandalaPattern,
+        accent: "text-primary",
+        badge: "bg-primary/10 ring-1 ring-primary/20",
+        ribbon: "from-primary/15",
+        cta: cn("bg-primary text-primary-foreground hover:bg-primary/90", CTA_TEAL),
+        liveGlow: "shadow-[0_6px_24px_rgba(29,126,142,0.45)]",
+    },
+    private: {
+        label: "Private",
+        Icon: User,
+        Pattern: LotusPattern,
+        accent: "text-secondary-foreground",
+        badge: "bg-secondary ring-1 ring-secondary-2/60",
+        ribbon: "from-secondary-3/20",
+        cta: cn(
+            "bg-secondary-3 text-white hover:bg-secondary-3/90",
+            CTA_ROSE,
+        ),
+        liveGlow: "shadow-[0_6px_24px_rgba(214,127,125,0.5)]",
+    },
+    b2b: {
+        label: "B2B",
+        Icon: Buildings,
+        Pattern: HexPattern,
+        accent: "text-violet-700 dark:text-violet-300",
+        badge: "bg-violet-500/10 ring-1 ring-violet-500/25",
+        ribbon: "from-violet-500/15",
+        cta: cn("bg-violet-600 text-white hover:bg-violet-700", CTA_VIOLET),
+        liveGlow: "shadow-[0_6px_24px_rgba(139,92,246,0.45)]",
+    },
+    outdoor: {
+        label: "Outdoor",
+        Icon: Sun1,
+        Pattern: SunPattern,
+        accent: "text-amber-700 dark:text-amber-400",
+        badge: "bg-amber-500/10 ring-1 ring-amber-500/45",
+        ribbon: "from-amber-500/15",
+        cta: cn("bg-amber-500 text-white hover:bg-amber-500/90", CTA_AMBER),
+        liveGlow: "shadow-[0_6px_24px_rgba(245,158,11,0.45)]",
+    },
+};
 
 export function EventCard({ event }: { event: CalendarEvent }) {
     const calendarLink = event.htmlLink as string | undefined;
     const startIso = event.start?.dateTime;
     const endIso = event.end?.dateTime;
-    
+
     if (!startIso || !endIso) return null; // Ignore all-day events for now
 
     const startTime = parseISO(startIso);
@@ -26,43 +93,72 @@ export function EventCard({ event }: { event: CalendarEvent }) {
     // Live if 'now' is between 15 mins before start and endTime
     const isLive = isWithinInterval(now, {
         start: subMinutes(startTime, 15),
-        end: endTime
+        end: endTime,
     });
 
-    const eventType = event.extendedProperties?.private?.jnaninEventType as string | undefined;
+    const eventType = event.extendedProperties?.private?.jnaninEventType as EventTypeKey | undefined;
     const outdoorPrice = event.extendedProperties?.private?.outdoorPrice as string | undefined;
+    const b2bPrice = event.extendedProperties?.private?.jnaninEventPrice as string | undefined;
+    const b2bPaxLabel = event.extendedProperties?.private?.jnaninB2BPaxLabel as string | undefined;
 
-    let badgeText = "Session";
-    let badgeVariant: "default" | "secondary" | "destructive" | "outline" = "outline";
+    const meta = (eventType && TYPE_META[eventType]) ?? null;
+    const TypeIcon = meta?.Icon;
+    const Pattern = meta?.Pattern;
 
-    switch (eventType) {
-        case "group":
-            badgeText = "Group Class";
-            badgeVariant = "default";
-            break;
-        case "private":
-            badgeText = "Private";
-            badgeVariant = "secondary";
-            break;
-        case "b2b":
-            badgeText = "B2B";
-            badgeVariant = "destructive";
-            break;
-        case "outdoor":
-            badgeText = `Outdoor (${outdoorPrice} MAD)`;
-            badgeVariant = "outline"; 
-            break;
-    }
+    // Off-site events are managed entirely in Google Calendar; no check-in to record.
+    const isOffsite = eventType === "b2b" || eventType === "outdoor";
 
     return (
-        <Card className={cn(
-            "group flex flex-col justify-between overflow-hidden rounded-3xl border-0 transition-all duration-300 ease-out md:flex-row md:items-center",
-            isLive ? "bg-card zen-shadow-md ring-primary/20 ring-1 hover:-translate-y-0.5" 
-                    : "bg-card zen-shadow opacity-95"
-        )}>
-            <div className="flex flex-1 flex-col justify-center p-6">
-                <div className="mb-1.5 flex items-center gap-3">
-                    <Badge variant={badgeVariant} className="rounded-full border-0 px-3 py-1 text-[10px] font-bold tracking-wider uppercase shadow-none">{badgeText}</Badge>
+        <Card
+            className={cn(
+                "group relative flex flex-col justify-between overflow-hidden rounded-3xl border-0 transition-all duration-300 ease-out md:flex-row md:items-center",
+                isLive
+                    ? "bg-card zen-shadow-md ring-primary/20 hover:zen-shadow-lg ring-1 hover:-translate-y-0.5"
+                    : "bg-card zen-shadow hover:zen-shadow-md hover:-translate-y-0.5",
+            )}
+        >
+            {/* Left edge accent — colored gradient bleed */}
+            {meta ? (
+                <div
+                    aria-hidden
+                    className={cn(
+                        "pointer-events-none absolute inset-y-0 left-0 w-32 bg-gradient-to-r to-transparent",
+                        meta.ribbon,
+                    )}
+                />
+            ) : null}
+
+            {/* Right background pattern — large, bleeding past the card edge, tinted with accent */}
+            {Pattern && meta ? (
+                <div
+                    aria-hidden
+                    className={cn(
+                        "pointer-events-none absolute -top-10 -right-16 h-[280px] w-[280px] opacity-[0.2] transition-all duration-700 ease-out group-hover:rotate-6 group-hover:opacity-[0.32]",
+                        meta.accent,
+                    )}
+                >
+                    <Pattern />
+                </div>
+            ) : null}
+
+            <div className="relative flex flex-1 flex-col justify-center p-6">
+                <div className="mb-3 flex items-center gap-3">
+                    {meta && TypeIcon ? (
+                        <span
+                            className={cn(
+                                "inline-flex items-center gap-1.5 rounded-full px-3 py-1 text-[10px] font-bold tracking-[0.14em] uppercase",
+                                meta.badge,
+                                meta.accent,
+                            )}
+                        >
+                            <TypeIcon className="h-3.5 w-3.5" variant="Bulk" />
+                            {meta.label}
+                        </span>
+                    ) : (
+                        <span className="bg-muted text-muted-foreground inline-flex items-center rounded-full px-3 py-1 text-[10px] font-bold tracking-[0.14em] uppercase">
+                            Session
+                        </span>
+                    )}
                     {isLive ? (
                         <span className="inline-flex items-center">
                             <span className="bg-destructive mr-1.5 h-2 w-2 animate-pulse rounded-full shadow-[0_0_8px_rgba(239,68,68,0.6)]"></span>
@@ -70,43 +166,78 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                         </span>
                     ) : null}
                 </div>
-                <CardTitle className="font-vibes text-foreground pr-2 text-3xl font-semibold capitalize" title={event.summary ?? undefined}>
+                <CardTitle
+                    className="font-heading text-foreground pr-2 text-2xl leading-tight font-semibold md:text-[1.7rem]"
+                    title={event.summary ?? undefined}
+                >
                     {event.summary || "Untitled Event"}
                 </CardTitle>
-                <div className="text-muted-foreground mt-2.5 flex items-center gap-3 text-sm font-medium">
+                <div className="text-muted-foreground mt-3 flex flex-wrap items-center gap-x-4 gap-y-1.5 text-sm font-medium">
                     <span className="flex items-center">
-                    <Clock className="mr-2 h-4 w-4" />
+                        <Clock className="mr-2 h-4 w-4" />
                         {format(startTime, "HH:mm")} - {format(endTime, "HH:mm")}
                     </span>
-                    <TooltipProvider delayDuration={150}>
-                    {calendarLink ? (
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <a
-                                    href={calendarLink}
-                                    target="_blank"
-                                    rel="noopener noreferrer"
-                                    title="Open in Google Calendar"
-                                    className="text-muted-foreground/60 hover:text-primary inline-flex items-center gap-1 transition-colors duration-200"
-                                >
-                                    <LinkCircle className="h-4 w-4" variant="Bulk" />
-                                </a>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                <p>Open in Google Calendar</p>
-                            </TooltipContent>
-                        </Tooltip>
+                    {eventType === "outdoor" && outdoorPrice ? (
+                        <span className="flex items-center">
+                            <Tag className="mr-2 h-4 w-4" variant="Bulk" />
+                            {outdoorPrice} MAD
+                        </span>
                     ) : null}
-                    </TooltipProvider>
+                    {eventType === "b2b" && (b2bPaxLabel || b2bPrice) ? (
+                        <span className="flex items-center">
+                            <Buildings className="mr-2 h-4 w-4" variant="Bulk" />
+                            {[b2bPaxLabel, b2bPrice ? `${b2bPrice} MAD` : null].filter(Boolean).join(" · ")}
+                        </span>
+                    ) : null}
+                    {!isOffsite && calendarLink ? (
+                        <a
+                            href={calendarLink}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="hover:text-primary inline-flex items-center gap-1.5 underline decoration-transparent underline-offset-4 transition-colors duration-200 hover:decoration-current"
+                        >
+                            <Calendar className="h-4 w-4" variant="Bulk" />
+                            <span>Open in Calendar</span>
+                        </a>
+                    ) : null}
                 </div>
             </div>
-            
-            <div className="mt-auto p-5 md:mt-0 md:bg-transparent md:p-6 md:pl-0">
-                <Button asChild className={cn("min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto", isLive && "zen-glow-teal")} variant={isLive ? "default" : "secondary"}>
-                    <Link href={`/check-in/${event.id}`}>
-                        Check In
-                    </Link>
-                </Button>
+
+            <div className="relative mt-auto p-5 md:mt-0 md:bg-transparent md:p-6 md:pl-0">
+                {isOffsite ? (
+                    <Button
+                        asChild
+                        disabled={!calendarLink}
+                        className={cn(
+                            "min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto",
+                            meta?.cta,
+                        )}
+                    >
+                        <a
+                            href={calendarLink ?? "#"}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            aria-label="Open in Google Calendar"
+                        >
+                            <Calendar className="mr-2 h-4 w-4" variant="Bulk" />
+                            Open in Calendar
+                        </a>
+                    </Button>
+                ) : (
+                    <Button
+                        asChild
+                        className={cn(
+                            "min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto",
+                            meta?.cta,
+                            isLive && meta?.liveGlow,
+                        )}
+                    >
+                        <Link href={`/check-in/${event.id}`}>
+                            <LoginCurve className="mr-2 h-4 w-4" variant="Bulk" />
+                            Check In
+                        </Link>
+                    </Button>
+                )}
             </div>
         </Card>
     );

--- a/components/schedule/events/card.tsx
+++ b/components/schedule/events/card.tsx
@@ -12,6 +12,7 @@ import { format, isWithinInterval, parseISO, subMinutes } from "date-fns";
 import type { Icon } from "iconsax-reactjs";
 import { Buildings, Calendar, Clock, LoginCurve, Profile2User, Sun1, Tag, User } from "iconsax-reactjs";
 
+import { CancelEventButton } from "./cancel-button";
 import { HexPattern, LotusPattern, MandalaPattern, SunPattern } from "./patterns";
 
 type EventTypeKey = "group" | "private" | "b2b" | "outdoor";
@@ -206,13 +207,16 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                 </div>
             </div>
 
-            <div className="relative mt-auto p-5 md:mt-0 md:bg-transparent md:p-6 md:pl-0">
+            <div className="relative mt-auto flex items-center gap-2 p-5 md:mt-0 md:bg-transparent md:p-6 md:pl-0">
+                {event.id ? (
+                    <CancelEventButton eventId={event.id} eventTitle={event.summary} />
+                ) : null}
                 {isOffsite ? (
                     <Button
                         asChild
                         disabled={!calendarLink}
                         className={cn(
-                            "min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto",
+                            "min-h-[48px] flex-1 rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:flex-none",
                             meta?.cta,
                         )}
                     >
@@ -230,7 +234,7 @@ export function EventCard({ event }: { event: CalendarEvent }) {
                     <Button
                         asChild
                         className={cn(
-                            "min-h-[48px] w-full rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:w-auto",
+                            "min-h-[48px] flex-1 rounded-2xl px-8 font-semibold transition-all md:min-h-[44px] md:flex-none",
                             meta?.cta,
                             isLive && meta?.liveGlow,
                         )}

--- a/components/schedule/events/patterns.tsx
+++ b/components/schedule/events/patterns.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { cn } from "@/lib/utils/ui";
+
+type PatternProps = { className?: string };
+
+// Shared SVG shell so every pattern has the same viewBox / stroke language.
+function Shell({ children, className }: { children: React.ReactNode } & PatternProps) {
+    return (
+        <svg
+            viewBox="0 0 240 240"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="0.7"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden
+            className={cn("h-full w-full", className)}
+        >
+            {children}
+        </svg>
+    );
+}
+
+// Group → Flower of Life. Seven interlocking circles = community, gathering.
+export function MandalaPattern({ className }: PatternProps) {
+    const ring = [
+        [120, 75],
+        [159, 97.5],
+        [159, 142.5],
+        [120, 165],
+        [81, 142.5],
+        [81, 97.5],
+    ] as const;
+    return (
+        <Shell className={className}>
+            <circle cx="120" cy="120" r="115" opacity="0.5" />
+            <circle cx="120" cy="120" r="100" strokeDasharray="1 4" />
+            <circle cx="120" cy="120" r="45" />
+            {ring.map(([x, y]) => (
+                <circle key={`${x}-${y}`} cx={x} cy={y} r="45" />
+            ))}
+            <circle cx="120" cy="120" r="22" />
+            <circle cx="120" cy="120" r="8" />
+        </Shell>
+    );
+}
+
+// Private → Eight-petal lotus. Single bloom = solitary focus, one-on-one.
+export function LotusPattern({ className }: PatternProps) {
+    const angles = [0, 45, 90, 135, 180, 225, 270, 315];
+    return (
+        <Shell className={className}>
+            <circle cx="120" cy="120" r="115" opacity="0.5" strokeDasharray="1 4" />
+            <circle cx="120" cy="120" r="90" opacity="0.4" />
+            <g transform="translate(120 120)">
+                {angles.map((deg) => (
+                    <ellipse key={deg} cx="0" cy="-55" rx="16" ry="55" transform={`rotate(${deg})`} />
+                ))}
+                {angles.map((deg) => (
+                    <ellipse
+                        key={`inner-${deg}`}
+                        cx="0"
+                        cy="-30"
+                        rx="8"
+                        ry="28"
+                        transform={`rotate(${deg + 22.5})`}
+                    />
+                ))}
+            </g>
+            <circle cx="120" cy="120" r="14" />
+            <circle cx="120" cy="120" r="5" />
+        </Shell>
+    );
+}
+
+// B2B → Honeycomb flower (7 hexes). Interlocking structure = partnerships.
+export function HexPattern({ className }: PatternProps) {
+    const centers = [
+        [120, 120],
+        [172, 120],
+        [146, 75],
+        [94, 75],
+        [68, 120],
+        [94, 165],
+        [146, 165],
+    ] as const;
+    const hex = "0,-30 -26,-15 -26,15 0,30 26,15 26,-15";
+    return (
+        <Shell className={className}>
+            <circle cx="120" cy="120" r="115" opacity="0.35" strokeDasharray="1 4" />
+            {centers.map(([x, y]) => (
+                <polygon key={`${x}-${y}`} points={hex} transform={`translate(${x} ${y})`} />
+            ))}
+            <polygon points="0,-12 -10,-6 -10,6 0,12 10,6 10,-6" transform="translate(120 120)" />
+            <circle cx="120" cy="120" r="3" fill="currentColor" stroke="none" />
+        </Shell>
+    );
+}
+
+// Outdoor → Sun with 16 rays. Openness, daylight, outside the studio walls.
+export function SunPattern({ className }: PatternProps) {
+    const rays = Array.from({ length: 16 }, (_, i) => i * 22.5);
+    return (
+        <Shell className={className}>
+            <circle cx="120" cy="120" r="115" opacity="0.4" strokeDasharray="1 4" />
+            <circle cx="120" cy="120" r="42" />
+            <circle cx="120" cy="120" r="56" opacity="0.5" />
+            <g transform="translate(120 120)">
+                {rays.map((deg) => (
+                    <line key={deg} x1="0" y1="-68" x2="0" y2="-100" transform={`rotate(${deg})`} />
+                ))}
+            </g>
+            <circle cx="120" cy="120" r="18" />
+            <circle cx="120" cy="120" r="6" fill="currentColor" stroke="none" />
+        </Shell>
+    );
+}

--- a/components/schedule/sessions/new-dialog.tsx
+++ b/components/schedule/sessions/new-dialog.tsx
@@ -28,6 +28,9 @@ import { type SessionFormValues,sessionSchema } from "@/lib/validators";
 
 import { zodResolver } from "@hookform/resolvers/zod";
 import { format, parse } from "date-fns";
+
+const todayStr = () => format(new Date(), "yyyy-MM-dd");
+const currentHourStr = () => format(new Date(), "HH:00");
 import { Refresh } from "iconsax-reactjs";
 import { toast } from "sonner";
 
@@ -84,6 +87,8 @@ export function NewSessionDialog({
 	}, [state, reset, onOpenChange, router]);
 
 	const selectedType = useWatch({ control, name: "type" });
+	const selectedDate = useWatch({ control, name: "dateStr" });
+	const isToday = selectedDate === todayStr();
 
 	const onSubmit = async (data: SessionFormValues) => {
 		try {
@@ -282,7 +287,9 @@ export function NewSessionDialog({
 						<Controller
 							control={control}
 							name="dateStr"
-							render={({ field }) => <Input type="date" {...field} />}
+							render={({ field }) => (
+								<Input type="date" min={todayStr()} {...field} />
+							)}
 						/>
 						{errors.dateStr ? (
 							<p className="text-sm text-red-500">{errors.dateStr.message}</p>
@@ -295,7 +302,13 @@ export function NewSessionDialog({
 							<Controller
 								control={control}
 								name="startTimeStr"
-								render={({ field }) => <Input type="time" {...field} />}
+								render={({ field }) => (
+									<Input
+										type="time"
+										min={isToday ? currentHourStr() : undefined}
+										{...field}
+									/>
+								)}
 							/>
 							{errors.startTimeStr ? (
 								<p className="text-sm text-red-500">

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils/ui";
+
+import { Accordion as AccordionPrimitive } from "radix-ui";
+import { ArrowDown2 } from "iconsax-reactjs";
+
+function Accordion({
+    ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Root>) {
+    return <AccordionPrimitive.Root data-slot="accordion" {...props} />;
+}
+
+function AccordionItem({
+    className,
+    ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Item>) {
+    return (
+        <AccordionPrimitive.Item
+            data-slot="accordion-item"
+            className={cn("border-b-0 last:border-b-0", className)}
+            {...props}
+        />
+    );
+}
+
+function AccordionTrigger({
+    className,
+    children,
+    ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Trigger>) {
+    return (
+        <AccordionPrimitive.Header className="flex">
+            <AccordionPrimitive.Trigger
+                data-slot="accordion-trigger"
+                className={cn(
+                    "focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-start justify-between gap-4 rounded-2xl text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] disabled:pointer-events-none disabled:opacity-50 [&[data-state=open]>svg]:rotate-180",
+                    className,
+                )}
+                {...props}
+            >
+                {children}
+                <ArrowDown2
+                    className="text-muted-foreground pointer-events-none size-4 shrink-0 translate-y-0.5 transition-transform duration-200"
+                    variant="Linear"
+                />
+            </AccordionPrimitive.Trigger>
+        </AccordionPrimitive.Header>
+    );
+}
+
+function AccordionContent({
+    className,
+    children,
+    ...props
+}: React.ComponentProps<typeof AccordionPrimitive.Content>) {
+    return (
+        <AccordionPrimitive.Content
+            data-slot="accordion-content"
+            className="data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down overflow-hidden text-sm"
+            {...props}
+        >
+            <div className={cn("pt-0 pb-4", className)}>{children}</div>
+        </AccordionPrimitive.Content>
+    );
+}
+
+export { Accordion, AccordionContent, AccordionItem, AccordionTrigger };

--- a/lib/actions/schedule/events.ts
+++ b/lib/actions/schedule/events.ts
@@ -28,22 +28,26 @@ export async function scheduleNewEventAction(data: ScheduleEventInput) {
 		return { error: "Not authenticated" };
 	}
 
-	// RULE 1: Shop Hours Verification
-	let workingHours = await getWorkingHours();
-	if (!workingHours) {
-		workingHours = DEFAULT_HOURS;
-	}
+	// RULE 1: Shop Hours Verification — only enforced for in-studio event types.
+	// B2B and outdoor sessions are held off-site and are not bound to studio hours.
+	const isStudioEvent = data.type === "group" || data.type === "private";
+	if (isStudioEvent) {
+		let workingHours = await getWorkingHours();
+		if (!workingHours) {
+			workingHours = DEFAULT_HOURS;
+		}
 
-	const dayConfig = workingHours[data.weekday.toString()];
-	if (!dayConfig || !dayConfig.isOpen) {
-		return { error: "Studio is closed on this day." };
-	}
+		const dayConfig = workingHours[data.weekday.toString()];
+		if (!dayConfig || !dayConfig.isOpen) {
+			return { error: "Studio is closed on this day." };
+		}
 
-	// Simple string comparison works for HH:mm formats (e.g. "08:00" >= "07:00")
-	if (data.startTimeStr < dayConfig.start || data.endTimeStr > dayConfig.end) {
-		return {
-			error: `Requested time is outside open hours. The studio is open from ${dayConfig.start} to ${dayConfig.end} on this day.`,
-		};
+		// Simple string comparison works for HH:mm formats (e.g. "08:00" >= "07:00")
+		if (data.startTimeStr < dayConfig.start || data.endTimeStr > dayConfig.end) {
+			return {
+				error: `Requested time is outside open hours. The studio is open from ${dayConfig.start} to ${dayConfig.end} on this day.`,
+			};
+		}
 	}
 
 	// Get Token

--- a/lib/actions/schedule/events.ts
+++ b/lib/actions/schedule/events.ts
@@ -1,7 +1,9 @@
 "use server";
 
+import { revalidatePath } from "next/cache";
+
 import { type ScheduleEventInput, type WorkingHoursConfig } from "@/lib/types";
-import { checkAvailability, createStudioEvent } from "@/services/google";
+import { cancelStudioEvent, checkAvailability, createStudioEvent } from "@/services/google";
 import { getValidAccessToken } from "@/services/google";
 import { createClient } from "@/services/supabase/server";
 
@@ -88,4 +90,42 @@ export async function scheduleNewEventAction(data: ScheduleEventInput) {
 		console.error("Failed to schedule event:", error);
 		return { error: "Failed to create the event in Google Calendar." };
 	}
+}
+
+/**
+ * Cancels an event by deleting it from Google Calendar. Local attendance
+ * records (if any) remain intact so past check-ins stay queryable.
+ */
+export async function cancelEventAction(eventId: string) {
+	if (!eventId) {
+		return { error: "Missing event id." };
+	}
+
+	const supabase = await createClient();
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	if (!user) {
+		return { error: "Not authenticated" };
+	}
+
+	let accessToken: string;
+	try {
+		accessToken = await getValidAccessToken(user.id);
+	} catch {
+		return { error: "Session expired or disconnected. Please relogin to sync with Google Calendar." };
+	}
+
+	try {
+		await cancelStudioEvent(accessToken, eventId);
+	} catch (error) {
+		console.error("Failed to cancel event:", error);
+		return { error: "Failed to cancel the event in Google Calendar." };
+	}
+
+	revalidatePath("/schedule");
+	revalidatePath("/");
+
+	return { success: true };
 }

--- a/lib/actions/schedule/events.ts
+++ b/lib/actions/schedule/events.ts
@@ -28,6 +28,13 @@ export async function scheduleNewEventAction(data: ScheduleEventInput) {
 		return { error: "Not authenticated" };
 	}
 
+	// RULE 0: Reject past events. Events must start from the current hour onwards.
+	const hourFloor = new Date();
+	hourFloor.setMinutes(0, 0, 0);
+	if (new Date(data.isoStart) < hourFloor) {
+		return { error: "Cannot schedule events in the past." };
+	}
+
 	// RULE 1: Shop Hours Verification — only enforced for in-studio event types.
 	// B2B and outdoor sessions are held off-site and are not bound to studio hours.
 	const isStudioEvent = data.type === "group" || data.type === "private";

--- a/lib/validators/session.ts
+++ b/lib/validators/session.ts
@@ -22,6 +22,20 @@ export const sessionSchema = z
 	)
 	.refine(
 		(data) => {
+			// Events can only start from the current hour onwards.
+			const eventStart = new Date(`${data.dateStr}T${data.startTimeStr}:00`);
+			if (isNaN(eventStart.getTime())) return true; // format issues handled elsewhere
+			const hourFloor = new Date();
+			hourFloor.setMinutes(0, 0, 0);
+			return eventStart >= hourFloor;
+		},
+		{
+			message: "Cannot schedule events in the past",
+			path: ["startTimeStr"],
+		},
+	)
+	.refine(
+		(data) => {
 			if (
 				data.type === "outdoor" &&
 				(!data.outdoorPrice || isNaN(Number(data.outdoorPrice)))

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "tw-animate-css": "^1.4.0",
     "typescript": "^6.0.3"
   },
-  "packageManager": "pnpm@10.33.0+sha512.10568bb4a6afb58c9eb3630da90cc9516417abebd3fabbe6739f0ae795728da1491e9db5a544c76ad8eb7570f5c4bb3d6c637b2cb41bfdcdb47fa823c8649319",
+  "packageManager": "pnpm@10.33.2+sha512.a90faf6feeab71ad6c6e57f94e0fe1a12f5dcc22cd754db40ae9593eb6a3e0b6b12e3540218bb37ae083404b1f2ce6db2a4121e979829b4aff94b99f49da1cf8",
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"

--- a/services/google/calendar.service.ts
+++ b/services/google/calendar.service.ts
@@ -179,6 +179,27 @@ export async function getUpcomingEvents(accessToken: string, daysForward = 7): P
 }
 
 /**
+ * Cancels (deletes) an event on the primary calendar. The event is removed
+ * from Google Calendar; attendance records stored locally are preserved.
+ */
+export async function cancelStudioEvent(
+	accessToken: string,
+	eventId: string,
+): Promise<void> {
+	const google = getGoogleClient(accessToken);
+
+	try {
+		await google.calendar.events.delete({
+			calendarId: "primary",
+			eventId,
+		});
+	} catch (error) {
+		console.error("Error cancelling Studio Event:", error);
+		throw new Error("Failed to cancel event in Google Calendar.");
+	}
+}
+
+/**
  * Fetches a specific event by its ID.
  */
 export async function getEventById(accessToken: string, eventId: string): Promise<CalendarEvent> {


### PR DESCRIPTION
Broadened beyond the original #8 scope into a comprehensive overhaul of the schedule sessions/events experience. Supersedes #9 (closed due to branch rename).

## Summary

- **Decouple B2B/Outdoor from studio hours** (#8) — working-hours gate now only applies to `group`/`private`; off-site events (b2b, outdoor) bypass it
- **Past-date guard** — three-layer protection so events can't be scheduled in the past (Zod refine, server action, form `min` attrs)
- **Event card remaster** — type-themed SVG patterns (mandala / lotus / honeycomb / sun), Philosopher serif title, per-type color identity (teal / rose / violet / amber) across badge, left ribbon, right pattern, CTA button, and hover glow
- **Live indicator → green** — matches `clients/grid.tsx` online treatment (pulsing ping+solid dot in a bordered green pill, green ring on the card) replacing the prior alarmy red destructive tone
- **Cancel sessions** — new `cancelStudioEvent` service + `cancelEventAction` server action; `CloseCircle` (X) button in top-right of the card with a destructive-themed `AlertDialog` confirming the irreversible action
- **Past events read-only** — cards go grayscale + muted, Check-In swaps to an outline "Attendance" button, cancel affordance hidden; the check-in page detects `isPast` and locks the manager to history mode (no search, no guardrail mutation path, relabeled heading/empty-state) so operators can't backfill attendees

Closes #8

## Test plan

### Decoupling (originally #8)
- [ ] On a weekday marked **closed** in Settings → Schedule: creating a \`group\`/\`private\` event still rejects with "Studio is closed on this day."
- [ ] Same day: creating a \`b2b\` or \`outdoor\` event succeeds
- [ ] Outside open hours on an open day: \`group\`/\`private\` rejected, \`b2b\`/\`outdoor\` succeeds

### Past-date guard
- [ ] Date picker in the new-session dialog blocks past dates
- [ ] Time picker blocks past hours when today is selected
- [ ] Server action rejects a past \`isoStart\` even if the form is bypassed

### Card visuals
- [ ] Each event type shows its own badge icon, pattern, ribbon, and CTA color
- [ ] Pattern rotates subtly and lifts in opacity on hover (for non-past events)
- [ ] CTA button lifts \`-translate-y-0.5\` and drops a colored shadow on hover

### Live state
- [ ] Event currently in progress: card gets a green ring, pulsing green dot + "Live" pill next to badge
- [ ] Same event's Check-In button keeps an always-on glow in the card's accent color (teal / rose)

### Cancel flow
- [ ] Top-right X on an upcoming event opens the destructive \`AlertDialog\`
- [ ] Dialog shows Danger icon + title on one row in destructive color
- [ ] Confirming deletes the Google Calendar event, schedule refreshes, toast appears
- [ ] Cancel X is not shown on past events

### Past events
- [ ] Past events render grayscaled + at 70% opacity, no hover lift
- [ ] Studio past event CTA reads "Attendance" with ClipboardTick icon
- [ ] Clicking Attendance lands on \`/check-in/[eventId]\` in history mode: no search bar, heading "Attendance Record", correct past-mode empty state
- [ ] Trying to check someone in via any residual path is a no-op (safety guard in \`onClientSelected\`)