### PR TITLE
feat(schedule, check-in): refresh loaders + scope check-in to studio sessions

### DIFF
--- a/app/(dashboard)/check-in/loading.tsx
+++ b/app/(dashboard)/check-in/loading.tsx
@@ -1,44 +1,49 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
+// Matches the remastered event card: rounded-3xl, left gradient, right pattern, CTA.
+function EventCardSkeleton() {
+	return (
+		<div className="bg-card border-border/70 relative flex flex-col justify-between overflow-hidden rounded-3xl border p-6 md:flex-row md:items-center">
+			<div className="bg-muted-foreground/5 pointer-events-none absolute inset-y-0 left-0 w-32" />
+			<div className="bg-muted-foreground/5 pointer-events-none absolute -top-10 -right-16 h-[280px] w-[280px] rounded-full" />
+
+			<div className="relative flex flex-1 flex-col gap-3">
+				<Skeleton className="bg-muted-foreground/10 h-5 w-24 rounded-full" />
+				<Skeleton className="bg-muted-foreground/15 h-7 w-56" />
+				<div className="flex items-center gap-3 pt-1">
+					<Skeleton className="bg-muted-foreground/10 h-4 w-28" />
+					<Skeleton className="bg-muted-foreground/10 h-4 w-32" />
+				</div>
+			</div>
+			<div className="relative mt-4 md:mt-0">
+				<Skeleton className="bg-muted-foreground/15 h-12 w-32 rounded-2xl" />
+			</div>
+		</div>
+	);
+}
+
 export default function Loading() {
 	return (
 		<>
-			{/* Header Skeleton */}
+			{/* Page header */}
 			<header className="flex flex-col space-y-2">
-				<Skeleton className="bg-muted-foreground/10 h-9 w-48" />
-				<Skeleton className="bg-muted-foreground/10 h-4 w-80" />
+				<Skeleton className="bg-muted-foreground/10 h-9 w-56" />
+				<Skeleton className="bg-muted-foreground/10 h-4 w-96" />
 			</header>
 
-			{/* Today's Agenda Card Skeleton */}
-			<div className="border-border/50 space-y-4 rounded-2xl border p-6 shadow-sm">
-				<div className="flex items-center justify-between">
-					<div className="space-y-2">
-						<Skeleton className="bg-muted-foreground/10 h-5 w-36" />
-						<Skeleton className="bg-muted-foreground/10 h-3 w-20" />
-					</div>
-					<Skeleton className="bg-muted-foreground/10 h-10 w-36 rounded-xl" />
+			{/* Today's Agenda bar (matches CockpitClient's top card: title + count + CTA) */}
+			<div className="bg-card zen-shadow flex items-center justify-between rounded-3xl p-5">
+				<div className="flex flex-col gap-2">
+					<Skeleton className="bg-muted-foreground/15 h-5 w-36" />
+					<Skeleton className="bg-muted-foreground/10 h-3 w-24" />
 				</div>
+				<Skeleton className="bg-muted-foreground/15 h-12 w-40 rounded-full" />
 			</div>
 
-			{/* Session Cards Skeleton */}
-			<div className="border-border/50 space-y-6 rounded-2xl border p-6 shadow-sm">
+			{/* Session cards */}
+			<div className="flex flex-col gap-3">
 				{Array.from({ length: 3 }).map((_, i) => (
-					<div
-						key={i}
-						className="bg-card flex items-center justify-between rounded-2xl p-4"
-					>
-						<div className="flex items-center gap-4">
-							<div className="space-y-2">
-								<Skeleton className="bg-muted-foreground/10 h-5 w-20 rounded-full" />
-								<Skeleton className="bg-muted-foreground/10 h-5 w-32" />
-								<div className="flex items-center gap-2">
-									<Skeleton className="bg-muted-foreground/10 h-4 w-4 rounded-full" />
-									<Skeleton className="bg-muted-foreground/10 h-4 w-24" />
-								</div>
-							</div>
-						</div>
-						<Skeleton className="bg-muted-foreground/10 h-10 w-24 rounded-xl" />
-					</div>
+					<EventCardSkeleton key={i} />
 				))}
 			</div>
 		</>

--- a/app/(dashboard)/check-in/page.tsx
+++ b/app/(dashboard)/check-in/page.tsx
@@ -19,7 +19,14 @@ export default async function CheckInIndexPage() {
 
     try {
         const token = await getValidAccessToken(user.id);
-        events = await getTodayEvents(token);
+        const todayEvents = await getTodayEvents(token);
+        // Check-in only applies to in-studio sessions (group, private). Off-site
+        // b2b/outdoor events are managed in Google Calendar and have no check-in
+        // workflow, so we filter them out of the portal to avoid confusion.
+        events = todayEvents.filter((e) => {
+            const type = e.extendedProperties?.private?.jnaninEventType;
+            return type === "group" || type === "private";
+        });
     } catch {
         errorMsg = "Please reconnect Google Calendar to view today's schedule.";
     }
@@ -28,9 +35,9 @@ export default async function CheckInIndexPage() {
         <>
             <header className="flex flex-col space-y-1">
                 <h1 className="font-heading text-foreground text-3xl font-medium tracking-tight md:text-4xl">Check-in Portal</h1>
-                <p className="text-md text-muted-foreground">Select a session from today&apos;s schedule to manage client attendance.</p>
+                <p className="text-md text-muted-foreground">Select a group or private studio session from today to manage client attendance.</p>
             </header>
-            
+
             <CockpitClient initialEvents={events} initialError={errorMsg} />
         </>
     );

--- a/app/(dashboard)/schedule/loading.tsx
+++ b/app/(dashboard)/schedule/loading.tsx
@@ -1,44 +1,81 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
+// One event card placeholder — matches the remastered card shape
+// (rounded-3xl, left accent gradient, right pattern area, title + meta + CTA).
+function EventCardSkeleton() {
+	return (
+		<div className="bg-card border-border/70 relative flex flex-col justify-between overflow-hidden rounded-3xl border p-6 md:flex-row md:items-center">
+			{/* left edge accent placeholder */}
+			<div className="bg-muted-foreground/5 pointer-events-none absolute inset-y-0 left-0 w-32" />
+			{/* right pattern placeholder */}
+			<div className="bg-muted-foreground/5 pointer-events-none absolute -top-10 -right-16 h-[280px] w-[280px] rounded-full" />
+
+			<div className="relative flex flex-1 flex-col gap-3">
+				<Skeleton className="bg-muted-foreground/10 h-5 w-24 rounded-full" />
+				<Skeleton className="bg-muted-foreground/15 h-7 w-56" />
+				<div className="flex items-center gap-3 pt-1">
+					<Skeleton className="bg-muted-foreground/10 h-4 w-28" />
+					<Skeleton className="bg-muted-foreground/10 h-4 w-24" />
+				</div>
+			</div>
+			<div className="relative mt-4 md:mt-0">
+				<Skeleton className="bg-muted-foreground/15 h-12 w-32 rounded-2xl" />
+			</div>
+		</div>
+	);
+}
+
+// Collapsed accordion row — just the date label + count pill + chevron.
+function AccordionCollapsedSkeleton() {
+	return (
+		<div className="bg-card border-border/70 zen-shadow flex items-center justify-between rounded-2xl border px-5 py-4">
+			<div className="flex items-center gap-3">
+				<Skeleton className="bg-muted-foreground/15 h-6 w-52" />
+			</div>
+			<div className="flex items-center gap-3">
+				<Skeleton className="bg-muted-foreground/10 h-6 w-24 rounded-full" />
+				<Skeleton className="bg-muted-foreground/10 h-4 w-4 rounded-full" />
+			</div>
+		</div>
+	);
+}
+
 export default function Loading() {
 	return (
 		<>
-			{/* Header Skeleton */}
+			{/* Header */}
 			<header className="flex flex-col space-y-2">
 				<Skeleton className="bg-muted-foreground/10 h-9 w-48" />
 				<Skeleton className="bg-muted-foreground/10 h-4 w-72" />
 			</header>
 
-			{/* Day Tabs Skeleton */}
-			<div className="flex gap-2 overflow-hidden">
-				{Array.from({ length: 7 }).map((_, i) => (
-					<Skeleton
-						key={i}
-						className="bg-muted-foreground/10 h-10 w-28 shrink-0 rounded-xl"
-					/>
-				))}
+			{/* New Session button (right-aligned) */}
+			<div className="flex justify-end">
+				<Skeleton className="bg-muted-foreground/15 h-10 w-44 rounded-xl" />
 			</div>
 
-			{/* Schedule Cards Skeleton */}
-			<div className="space-y-4">
-				{Array.from({ length: 4 }).map((_, i) => (
-					<div
-						key={i}
-						className="border-border/50 bg-card flex items-center justify-between rounded-2xl border p-5 shadow-sm"
-					>
-						<div className="flex items-center gap-4">
-							<Skeleton className="bg-muted-foreground/10 h-12 w-12 rounded-xl" />
-							<div className="space-y-2">
-								<Skeleton className="bg-muted-foreground/10 h-5 w-40" />
-								<Skeleton className="bg-muted-foreground/10 h-4 w-28" />
-							</div>
+			{/* Accordion list — a few collapsed days and one expanded (today) with event cards */}
+			<div className="flex flex-col gap-3">
+				{/* Expanded (today) */}
+				<div className="bg-card border-border/70 zen-shadow rounded-2xl border px-5 pt-4 pb-5">
+					<div className="mb-3 flex items-center justify-between">
+						<div className="flex items-center gap-3">
+							<Skeleton className="bg-muted-foreground/15 h-6 w-52" />
+							<Skeleton className="bg-primary/20 h-5 w-14 rounded-full" />
 						</div>
 						<div className="flex items-center gap-3">
-							<Skeleton className="bg-muted-foreground/10 h-8 w-20 rounded-lg" />
-							<Skeleton className="bg-muted-foreground/10 h-10 w-24 rounded-xl" />
+							<Skeleton className="bg-muted-foreground/10 h-6 w-24 rounded-full" />
+							<Skeleton className="bg-muted-foreground/10 h-4 w-4 rounded-full" />
 						</div>
 					</div>
-				))}
+					<div className="flex flex-col gap-3 pt-2">
+						<EventCardSkeleton />
+						<EventCardSkeleton />
+					</div>
+				</div>
+				<AccordionCollapsedSkeleton />
+				<AccordionCollapsedSkeleton />
+				<AccordionCollapsedSkeleton />
 			</div>
 		</>
 	);


### PR DESCRIPTION
Bring the loading skeletons in line with the remastered event card and new accordion timeline, and scope the check-in portal strictly to the sessions it can actually act on.

Schedule loader (app/(dashboard)/schedule/loading.tsx)
- Replaces the stale 7-tab row + flat cards with the accordion shape: an expanded "today" row containing two event-card skeletons plus three collapsed-row skeletons showing the date label + count pill + chevron placeholder
- Event-card skeleton mirrors the remastered card (rounded-3xl, subtle border, left-gradient and right-pattern placeholders, meta + CTA)

Check-in portal (app/(dashboard)/check-in/page.tsx)
- Off-site events (b2b, outdoor) are managed in Google Calendar and have no check-in flow, so they're filtered out by jnaninEventType. The portal now only lists today's group and private studio sessions
- Copy updated to name the filter: "Select a group or private studio session from today to manage client attendance."

Check-in portal loader (app/(dashboard)/check-in/loading.tsx)
- Matches CockpitClient: page header, the rounded-3xl "Today's Agenda" bar with title + count + CTA placeholders, and three event-card skeletons using the same shape as the schedule loader